### PR TITLE
Add docs for sibling count attribute on sections with version bump

### DIFF
--- a/old-versions/2.md
+++ b/old-versions/2.md
@@ -18,7 +18,7 @@ But we could have passed the parsed template instead:
 ```js
 var ractive = new Ractive({
   el: 'body',
-  template: {v:3,t:[{t:7,e:'h1',f:['Hello ',{t:2,r:'name'},'!']}]},
+  template: {v:2,t:[{t:7,e:'h1',f:['Hello ',{t:2,r:'name'},'!']}]},
   data: { name: 'world' }
 });
 ```
@@ -45,14 +45,14 @@ Some terminology:
 
 ## Version
 
-This is **version 3** of the specification, as shown by the `v: 3` in the [structure](#structure) section below. This ensures that your build tools, or server-side compile steps, are speaking the same language as the copy of Ractive running in your app in the browser.
+This is **version 2** of the specification, as shown by the `v: 2` in the [structure](#structure) section below. This ensures that your build tools, or server-side compile steps, are speaking the same language as the copy of Ractive running in your app in the browser.
 
 
 ## Structure
 
 ```js
 {
-  v: 3, /* Template spec version */
+  v: 2, /* Template spec version */
   t: [  /* items in the main template */ ],
   p: {  /* Optional hash of partials */
     foo: [ /* items in the 'foo' partial */ ]
@@ -176,33 +176,6 @@ Expressions and reference expressions can also be used with [triples](#triple) a
 }
 ```
 
-Sections may have a number of siblings designated by the attribute `b`. This is currently used to allow conditional sections to include additional branches without having to come up with an inverted conditional or group of conditionals.
-
-```js
-// Before
-'{{#foo}}...{{else if bar}}...{{else}}...{{/}}'
-
-// After
-[{
-  t: 4,
-  b: 2, // the number of siblings that follow
-  r: 'foo',
-  f: ['...'] // the first section fragment
-},
-{
-  t: 4,
-  x: { r: ['bar'], s: '_1' },
-  f: ['...'] // the second section fragment
-},
-{
-  t: 4,
-  x: { r: [], s: 'true' },
-  f: ['...'] // the third section fragment
-}]
-```
-
-In this example, the sibling conditional references have been replaced with expressions since that is what the parser currently does. It is not necessary though, except in the case of `else` where an expression is the only way to evaluate a `true` directly.
-
 Sections can be 'inverted' - in other words, they only render when their condition (`foo` in the example) is falsy:
 
 ```js
@@ -218,33 +191,7 @@ Sections can be 'inverted' - in other words, they only render when their conditi
 }
 ```
 
-The current parser does not generate simple inverted sections, but instead generates a Handlebars `unless` section, as described below.
-
-#### Handlebars
-
-In regular Mustache, lists, objects and conditional sections are all treated similarly, and differentiated at render time. Only inverted sections look different. [Handlebars](http://handlebarsjs.com/) allows the template author to specify the type of section, which is useful. Ractive also supports this using a subtype indicator for sections.
-
-```js
-// Before
-'{{#if foo}}...{{/if}}'
-
-// After
-{
-  t: 4,
-  r: 'foo',
-  f: ['...'],
-  n: 50 // designates an if section
-}
-```
-
-There are six subtypes available for sections.
-
-1. `50` - `SECTION_IF` - an explicit conditional section (`{{#if foo}}...{{/if}}`)
-2. `51` - `SECTION_UNLESS` - an inverted explicit conditional section (`{{#unless foo}}...{{/unless}}`)
-3. `52` - `SECTION_EACH` - an explicit iterative section (`{{#each foo}}...{{/each}}`)
-4. `53` - `SECTION_WITH` - an explicit context section (`{{#with foo}}...{{/with}}`)
-5. `54` - `SECTION_IF_WITH` - a special case context section that acts as a conditional if its value is false (`{{#with foo}}...{{else}}...{{/with}}`)
-6. `55` - `SECTION_PARTIAL` - a named partial definition section (`{{#partial foo}}...{{/partial}}`) - **These should not appear in the parsed template** as they are moved to their nearest Ractive insance (component or root) as a late step in the current parse process.
+Note: this will likely change in the near future. In regular Mustache, lists, objects and conditional sections are all treated similarly, and differentiated at render time. Only inverted sections look different. Some templating languages, e.g. [Handlebars](http://handlebarsjs.com/), allow the template author to specify the type of section, which is useful.
 
 
 ### Element
@@ -282,22 +229,6 @@ An 'element' may in fact be a component - this is determined at render time. As 
     }
   },
   f: ['...']         // element children fragment
-}
-```
-
-If an element is a component, it may also have partials attached for use as partial overrides or yields within the component. The current parser only attaches partials to an element if it knows ahead of time that the element will be a component.
-
-```js
-// Before
-'<cmp>{{#partial foo}}...{{/partial}}</cmp>'
-
-// After
-{
-  t: 7,
-  e: 'cmp'
-  p: {
-    foo: ['...'] // the fragment body
-  }
 }
 ```
 


### PR DESCRIPTION
Also, inline partials and handlebars sections, which are both technically in the v2 parser, I think.
